### PR TITLE
Add support for custom I2C bus in order to use non-default SDA/SCL pins

### DIFF
--- a/src/MQ-Sensor-SOLDERED.cpp
+++ b/src/MQ-Sensor-SOLDERED.cpp
@@ -14,11 +14,11 @@
 /**
  * @brief                   Overloaded function for virtual in base class to initialize sensor specific.
  */
-void MQ_Sensor::begin(int _addr)
+void MQ_Sensor::begin(int _addr, TwoWire *pWire)
 {
     if (_addr)
     {
-        init(_addr);
+        init(_addr, pWire);
     }
     else
     {

--- a/src/MQ-Sensor-SOLDERED.h
+++ b/src/MQ-Sensor-SOLDERED.h
@@ -49,7 +49,7 @@ class MQ_Sensor : public MQUnifiedsensor
         }
     }
 
-    void begin(int _addr = 0x00);
+    void begin(int _addr = 0x00, TwoWire *pWire = &Wire);
 
     bool digitalRead();
 

--- a/src/libs/MQUnifiedsensor/src/MQUnifiedsensor.cpp
+++ b/src/libs/MQUnifiedsensor/src/MQUnifiedsensor.cpp
@@ -10,11 +10,11 @@ MQUnifiedsensor::MQUnifiedsensor(int pin, String Placa, float Voltage_Resolution
     this->_VOLT_RESOLUTION = Voltage_Resolution;
     this->_ADC_Bit_Resolution = ADC_Bit_Resolution;
 }
-void MQUnifiedsensor::init(int _addr)
+void MQUnifiedsensor::init(int _addr, TwoWire *pWire)
 {
     addr = _addr;
-
-    Wire.begin();
+    _pWire = pWire;
+    _pWire->begin();
 }
 void MQUnifiedsensor::setA(float a)
 {
@@ -166,9 +166,9 @@ void MQUnifiedsensor::update()
     else
     {
         uint8_t temp[2];
-        Wire.requestFrom(addr, 2);
-        temp[0] = Wire.read();
-        temp[1] = Wire.read();
+        _pWire->requestFrom(addr, (byte) 2);
+        temp[0] = _pWire->read();
+        temp[1] = _pWire->read();
         _adc = (temp[0] | temp[1] << 8);
         _sensor_volt = _adc / 1024.0 * _VOLT_RESOLUTION;
     }

--- a/src/libs/MQUnifiedsensor/src/MQUnifiedsensor.h
+++ b/src/libs/MQUnifiedsensor/src/MQUnifiedsensor.h
@@ -18,7 +18,7 @@ class MQUnifiedsensor
                     String type = "CUSTOM MQ");
 
     // Functions to set values
-    void init(int addr);
+    void init(int addr, TwoWire *pWire);
     void update();
     void setR0(float R0 = 10);
     void setRL(float RL = 10);
@@ -59,6 +59,7 @@ class MQUnifiedsensor
 
     float _adc, _a, _b, _sensor_volt;
     float _R0, RS_air, _ratio, _PPM, _RS_Calc;
+    TwoWire* _pWire;
 
     char _type[6];
     char _placa[20];


### PR DESCRIPTION
For reference, this addresses #1.